### PR TITLE
feat: Add no_log input parameter to Ansible deployment options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,23 @@
+<!-- omit in toc -->
 # Ansible Deployment Action
+
+<!-- omit in toc -->
+## Content
+
+- [Overview](#overview)
+- [Usage](#usage)
+  - [Example usage](#example-usage)
+
+## Overview
 
 This GitHub Action facilitates Ansible deployments, allowing you to run Ansible playbooks with ease. It provides options to configure playbook paths, AWS regions, run modes, and secrets for secure deployment.
 
 ## Usage
 
-See [action.yml](action.yml)
+See [action.yml](action.yml).
 
 ``` yaml
-- uses: actions/ansible-deployment@v1
+- uses: actions/ansible-deployment@v0.0.3
   with:
     # Optional. Specifies the path to the playbook
     playbook_path: 'playbooks'
@@ -17,6 +27,11 @@ See [action.yml](action.yml)
 
     # Optional. Set to true to run Ansible playbooks in --check mode
     dry_run: false
+
+    # Optional. Set no_log to 'false' to let tasks log all output
+    # WARNING! If you set no_log to 'false', sensitive credentials may be log
+    # into the console. Default is 'true'
+    no_log: true
 
     # Specifies the AWS region name for configuration
     aws_region: ''
@@ -32,7 +47,7 @@ See [action.yml](action.yml)
     # Optional. AWS service account access key
     aws_access_key_id: ''
 
-    # Ensure the following values are treated as secrets:
+    # Ensure the following values are treated as secrets!
 
     # Optional. Ansible vault password to decrypt secrets
     ansible_vault_password: ''
@@ -41,15 +56,16 @@ See [action.yml](action.yml)
     aws_secret_access_key: ''
 ```
 
-Example usage:
+### Example usage
 
 ```yaml
-- uses: gbh-tech/ansible-deployment@v1
+- uses: gbh-tech/ansible-deployment@v0.0.3
   with:
     playbook_path: 'playbooks'
     playbook_name: 'stage.yaml'
     workdir: 'ansible'
     dry_run: true
+    no_log: true
     aws_region: 'us-east-1'
     ansible_vault_password: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
     aws_access_key_id: ${{ vars.AWS_ACCESS_KEY_ID }}

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
     description: 'Whenever to run Ansible on check mode'
     required: false
     default: 'false'
+  no_log:
+    description: 'Whether to log the output of the Playbook'
+    default: 'true'
   aws_region:
     description: 'AWS runner region'
     required: false
@@ -60,36 +63,40 @@ runs:
 
     - name: Set Ansible configuration and dry run options
       shell: bash -leo pipefail {0}
-      working-directory: ${{ inputs.workdir }}
+      working-directory: '${{ inputs.workdir }}'
       run: |
         set_env() { echo "$1" >> $GITHUB_ENV; }
         echo "Dry Run set to: ${{ inputs.dry_run }}"
 
-        if [ "${{ inputs.dry_run }}" == "true" ]; then
+        if [[ "${{ inputs.dry_run }}" == "true" ]]; then
           set_env "OPTS=--check"
         else
           set_env "OPTS="
         fi
 
-        sed -i "/- hosts:/a\  no_log: yes" ${{ inputs.playbook_path }}/site.yml
+        if [[ "${{ inputs.no_log }}" == "true" ]]; then
+          sed -i "/- hosts:/a\  no_log: true" ${{ inputs.playbook_path }}/site.yml
+        fi
 
     - name: Add Ansible vault password to vault key file
       shell: bash -leo pipefail {0}
       if: ${{ inputs.ansible_vault_password != '' }}
-      working-directory: ${{ inputs.workdir }}
+      working-directory: '${{ inputs.workdir }}'
       run: echo "${{ inputs.ansible_vault_password }}" > vault.key
 
     - name: Running Ansible tasks
       shell: bash -leo pipefail {0}
-      working-directory: ${{ inputs.workdir }}
+      working-directory: '${{ inputs.workdir }}'
       run: |
         tags="${{ inputs.ansible_tags }}"
 
         # Set the IFS to comma (,) to split the string based on comma
         IFS=','
 
-        read -ra array <<< "$tags"
-        for tag in ${array[@]}
-          do
-            ansible-playbook ${{ inputs.playbook_path }}/${{ inputs.playbook_name }}.yml -t $tag ${{ env.OPTS }}
-          done
+        read -ra array <<< "${tags}"
+        for tag in "${array[@]}"; do
+          ansible-playbook \
+          "${{ inputs.playbook_path }}/${{ inputs.playbook_name }}.yml" \
+          -t "${tag}" \
+          "${{ env.OPTS }}"
+        done


### PR DESCRIPTION
## Summary
- We need to be able to set `no_log` to `false` sometimes for troubleshooting purposes.